### PR TITLE
Get rcpt_to from data instead of the {rcpt_addr} macro

### DIFF
--- a/libmilter.py
+++ b/libmilter.py
@@ -815,8 +815,8 @@ class MilterProtocol(object):
         data = data[0]
         rcpt = ''
         if data:
-            rcpt = data[1:-1]
-        if md.has_key('rcpt_addr'):
+            rcpt = data[2:-2]
+        elif md.has_key('rcpt_addr'):
             rcpt = md['rcpt_addr']
         if md.has_key('i'):
             self._qid = md['i']


### PR DESCRIPTION
They are the same in sendmail, but postfix only sends lowercase {rcpt_addr} even when the address is upper or mixed.

For a background, you can view my posting to the postfix mailing list detailing this problem:
http://groups.yahoo.com/neo/groups/postfix-users/conversations/topics/296507
