### PR TITLE
fix: rcpt gets cut off

### DIFF
--- a/libmilter.py
+++ b/libmilter.py
@@ -815,7 +815,7 @@ class MilterProtocol(object):
         data = data[0]
         rcpt = ''
         if data:
-            rcpt = data[2:-2]
+            rcpt = data[1:-1]
         elif md.has_key('rcpt_addr'):
             rcpt = md['rcpt_addr']
         if md.has_key('i'):


### PR DESCRIPTION
for me, using postfix, `data[0] = 'Rpost@example.com\x00'` gets cut to `ost@example.co` due to `rcpt = data[2:-2]`

please correct me if that error comes from somewhere else.