### PR TITLE
Respect Postfix's milter_default_action

### DIFF
--- a/libmilter.py
+++ b/libmilter.py
@@ -467,7 +467,6 @@ class ThreadMixin(threading.Thread):
                 if DEBUG:
                     traceback.print_exc()
                     debug('AN EXCEPTION OCCURED: %s' % e , 1 , self.id)
-                self.send(TEMPFAIL)
                 self.connectionLost()
                 break
 # }}}
@@ -509,7 +508,6 @@ class ForkMixin(object):
                 if DEBUG:
                     traceback.print_exc()
                     debug('AN EXCEPTION OCCURED: %s' % e , 1 , self.id)
-                self.send(TEMPFAIL)
                 self.connectionLost()
                 break
         #self.log('Exiting child process')
@@ -1311,7 +1309,6 @@ class AsyncFactory(object):
                             traceback.print_exc()
                         print >> sys.stderr , 'AN EXCEPTION OCCURED IN ' \
                             '%s: %s' % (p.id , e)
-                        p.send(TEMPFAIL)
                         p.connectionLost()
                         self.unregister(fd)
             # Check the deferreds


### PR DESCRIPTION
Hi, thanks for writing python-libmilter! I noticed my milter dropped mails when the milter gave an exception. I pinpointed this at the exception handlers that indicate temporary failure. By not explicitly giving a status back, you can use the Postfix "milter_default_action" setting. With this patch and the setting on "accept", you'll get mail even when the milter fails. Postfix's default is "milter_default_action = tempfail", like the default in python-libmilter.

Hope to hear if you like this patch,
Wessel

P.S. First pull request, let me know if it's not quite right